### PR TITLE
Add Pi-hole log monitoring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # tinder-detector
+
+This repository contains a simple script for monitoring a Pi-hole instance for DNS queries to selected dating domains (`tinder.com`, `badoo.com`, `sympatia.pl`).
+
+The script `pihole_monitor.py` reads only new lines from `/var/log/pihole.log` since the previous run and sends notifications via Mailgun when a new client IP is detected querying one of these domains. State is stored in `/var/tmp/pihole_monitor_state.json`.
+
+## Usage
+
+```bash
+pip install --user requests  # first time only
+python3 pihole_monitor.py [-d]
+```
+
+Use the `-d` or `--debug` flag to print additional debugging information.
+
+Mailgun API credentials must be provided via the following environment variables:
+
+- `MAILGUN_API_KEY`
+- `MAILGUN_DOMAIN`
+- `MAILGUN_FROM`
+- `MAILGUN_TO`
+
+The script is designed to be lightweight and can be scheduled via cron for periodic monitoring.

--- a/pihole_monitor.py
+++ b/pihole_monitor.py
@@ -1,0 +1,109 @@
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Dict, Set
+
+import requests
+
+LOG_PATH = '/var/log/pihole.log'
+STATE_PATH = '/var/tmp/pihole_monitor_state.json'
+TARGET_DOMAINS = ['tinder.com', 'badoo.com', 'sympatia.pl']
+LOG_PATTERN = re.compile(r"query\[[^\]]+\]\s+(?P<domain>\S+)\s+from\s+(?P<ip>\S+)")
+
+def load_state(path: str) -> Dict:
+    if os.path.exists(path):
+        with open(path, 'r') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+def save_state(path: str, state: Dict) -> None:
+    tmp_path = path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        json.dump(state, f)
+    os.replace(tmp_path, path)
+
+def send_mail(domain: str, ip: str, raw_domain: str, debug: bool = False) -> None:
+    api_key = os.getenv('MAILGUN_API_KEY')
+    mg_domain = os.getenv('MAILGUN_DOMAIN')
+    from_addr = os.getenv('MAILGUN_FROM')
+    to_addr = os.getenv('MAILGUN_TO')
+    if not all([api_key, mg_domain, from_addr, to_addr]):
+        if debug:
+            print('Mailgun environment variables not fully configured')
+        return
+    subject = f'Pi-hole detection: {raw_domain} from {ip}'
+    text = f'Domain: {raw_domain}\nClient IP: {ip}\nMatched pattern: {domain}'
+    if debug:
+        print('Sending email:', subject)
+    try:
+        resp = requests.post(
+            f'https://api.mailgun.net/v3/{mg_domain}/messages',
+            auth=('api', api_key),
+            data={
+                'from': from_addr,
+                'to': [to_addr],
+                'subject': subject,
+                'text': text,
+            },
+            timeout=10,
+        )
+        if debug:
+            print('Mailgun response:', resp.status_code, resp.text)
+    except Exception as e:
+        if debug:
+            print('Failed to send email:', e)
+
+def process_log(debug: bool = False) -> None:
+    state = load_state(STATE_PATH)
+    offset = state.get('offset', 0)
+    seen: Dict[str, Set[str]] = {k: set(v) for k, v in state.get('seen', {}).items()}
+
+    try:
+        f = open(LOG_PATH, 'r')
+    except FileNotFoundError:
+        if debug:
+            print('Log file not found:', LOG_PATH)
+        return
+
+    with f:
+        f.seek(0, os.SEEK_END)
+        end = f.tell()
+        if offset > end:
+            offset = 0  # log rotated
+        f.seek(offset)
+        for line in f:
+            if debug:
+                print('LINE:', line.strip())
+            m = LOG_PATTERN.search(line)
+            if not m:
+                continue
+            raw_domain = m.group('domain').lower()
+            ip = m.group('ip')
+            for target in TARGET_DOMAINS:
+                if raw_domain == target or raw_domain.endswith('.' + target):
+                    if ip not in seen or target not in seen[ip]:
+                        send_mail(target, ip, raw_domain, debug)
+                        seen.setdefault(ip, set()).add(target)
+        new_offset = f.tell()
+
+    state = {
+        'offset': new_offset,
+        'seen': {k: list(v) for k, v in seen.items()},
+    }
+    save_state(STATE_PATH, state)
+    if debug:
+        print('State saved. Offset:', new_offset)
+
+def main():
+    parser = argparse.ArgumentParser(description='Monitor Pi-hole log for specific domains')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug output')
+    args = parser.parse_args()
+    process_log(debug=args.debug)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `pihole_monitor.py` for detecting DNS queries to tinder.com, badoo.com and sympatia.pl
- update README with usage instructions

## Testing
- `python3 -m py_compile pihole_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_684460fa4a9c83258f61068c7387be34