### PR TITLE
Limit debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ pip install --user requests  # tylko przy pierwszym użyciu
 python3 pihole_monitor.py [-d]
 ```
 
-Przełącznik `-d` lub `--debug` wyświetla dodatkowe informacje diagnostyczne.
+Tryb debugowania (`-d` lub `--debug`) wyświetla jedynie istotne zdarzenia
+(np. wykryte zapytania i odpowiedzi Mailguna), pomijając pełne linie z
+`pihole.log`.
 
 Dane logowania do Mailguna można podać w pliku `tinder-detector.conf` lub w
 następujących zmiennych środowiskowych:

--- a/pihole_monitor.py
+++ b/pihole_monitor.py
@@ -102,8 +102,8 @@ def process_log(debug: bool = False) -> None:
             offset = 0  # log rotated
         f.seek(offset)
         for line in f:
-            if debug:
-                print('LINE:', line.strip())
+            # Print only relevant events in debug mode, not full log lines
+            # to avoid cluttering the output with raw log contents.
             m = LOG_PATTERN.search(line)
             if not m:
                 continue
@@ -111,6 +111,8 @@ def process_log(debug: bool = False) -> None:
             ip = m.group('ip')
             for target in TARGET_DOMAINS:
                 if raw_domain == target or raw_domain.endswith('.' + target):
+                    if debug:
+                        print('Match:', raw_domain, 'from', ip)
                     if ip not in seen or target not in seen[ip]:
                         if send_mail(target, ip, raw_domain, debug):
                             seen.setdefault(ip, set()).add(target)


### PR DESCRIPTION
## Summary
- cut raw log lines from debug output
- log match events only in debug mode
- clarify README about debug mode

## Testing
- `python3 -m py_compile pihole_monitor.py`
- `python3 pihole_monitor.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68446e76ebf48325a794a248eebd86ee