### PR TITLE
Add configurable Mailgun API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ następujących zmiennych środowiskowych:
 
 - `MAILGUN_API_KEY`
 - `MAILGUN_DOMAIN`
+- `MAILGUN_API_URL` (domyślnie `https://api.mailgun.net`)
 - `MAILGUN_FROM`
 - `MAILGUN_TO`
+
+Mailgun udostępnia dwa regiony API: US (domyślny) i EU.
+Odpowiednie adresy to `https://api.mailgun.net` oraz
+`https://api.eu.mailgun.net`. W pliku konfiguracyjnym (`api_url`) lub w
+zmiennej `MAILGUN_API_URL` możesz wybrać region EU.
 
 Przykładowy plik konfiguracyjny znajduje się w `tinder-detector.conf.sample`.
 Po instalacji skopiuj go do `tinder-detector.conf` i uzupełnij wartości.

--- a/pihole_monitor.py
+++ b/pihole_monitor.py
@@ -31,6 +31,7 @@ LOG_PATTERN = re.compile(r"query\[[^\]]+\]\s+(?P<domain>\S+)\s+from\s+(?P<ip>\S+
 
 MAILGUN_API_KEY = _cfg.get('api_key') or os.getenv('MAILGUN_API_KEY')
 MAILGUN_DOMAIN = _cfg.get('mg_domain') or os.getenv('MAILGUN_DOMAIN')
+MAILGUN_API_URL = _cfg.get('api_url') or os.getenv('MAILGUN_API_URL', 'https://api.mailgun.net')
 MAILGUN_FROM = _cfg.get('from_addr') or os.getenv('MAILGUN_FROM')
 MAILGUN_TO = _cfg.get('to_addr') or os.getenv('MAILGUN_TO')
 
@@ -64,7 +65,7 @@ def send_mail(domain: str, ip: str, raw_domain: str, debug: bool = False) -> boo
         print('Sending email:', subject)
     try:
         resp = requests.post(
-            f'https://api.mailgun.net/v3/{mg_domain}/messages',
+            f'{MAILGUN_API_URL}/v3/{mg_domain}/messages',
             auth=('api', api_key),
             data={
                 'from': from_addr,

--- a/tinder-detector.conf.sample
+++ b/tinder-detector.conf.sample
@@ -1,7 +1,9 @@
-# Skopiuj ten plik do 'tinder-detector.conf' i uzupelnij wartosci
+# Skopiuj ten plik do 'tinder-detector.conf' i uzupełnij wartości
 # danych logowania do Mailguna.
 
 api_key = MAILGUN_API_KEY
 mg_domain = MAILGUN_DOMAIN
+api_url = https://api.mailgun.net
+# api_url = https://api.eu.mailgun.net
 from_addr = MAILGUN_FROM
 to_addr = MAILGUN_TO


### PR DESCRIPTION
## Summary
- allow setting Mailgun API URL in configuration and env var
- document the EU region

## Testing
- `python3 -m py_compile pihole_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6844709c6f4c8325b0c298c9f2138101