### PR TITLE
Dodano czas i polskie treści w powiadomieniach

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 To repozytorium zawiera prosty skrypt do monitorowania instancji Pi-hole w poszukiwaniu zapytań DNS do wybranych serwisów randkowych (`tinder.com`, `badoo.com`, `sympatia.pl`).
 
 Skrypt `pihole_monitor.py` odczytuje jedynie nowe linie z `/var/log/pihole/pihole.log` od poprzedniego uruchomienia i wysyła powiadomienia przez Mailgun, gdy wykryje nowe IP klienta pytające o jedną z tych domen. Stan jest zapisywany w `/var/tmp/pihole_monitor_state.json`.
+Temat oraz treść wysyłanych e‑maili zawierają wykrytą domenę, adres IP klienta oraz czas ostatniego zapytania.
 
 ## Użycie
 


### PR DESCRIPTION
## Podsumowanie
- uwzględniono czas w wysyłanych powiadomieniach
- temat i treść maila są teraz po polsku
- opis w README aktualizuje informację o zawartości e-maili

## Testy
- `python3 -m py_compile pihole_monitor.py`
- `python3 pihole_monitor.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68447341f6a48325ac4a6d5dce293057