### PR TITLE
Ensure script runs from its own directory

### DIFF
--- a/pihole_monitor.py
+++ b/pihole_monitor.py
@@ -7,6 +7,11 @@ from typing import Dict, Set
 
 import requests
 
+# Ensure the working directory is the script's directory so that relative
+# paths (like the configuration file) resolve correctly when the script is
+# run from cron or other automated jobs.
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'tinder-detector.conf')
 
 def load_config(path: str) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- set working directory to script location so cron jobs find config

## Testing
- `python3 -m py_compile pihole_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6844795691c48325baddef63d9610055